### PR TITLE
LCPI-994 Add Docker Onload Image for Ubuntu 20 and 22

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -84,6 +84,7 @@ RUN \
         unzip \
         valgrind \
         wget \
+        libcap-dev \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
           curl --insecure -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -87,6 +87,7 @@ RUN \
         util-linux \
         valgrind \
         wget \
+        libcap-dev \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 \

--- a/jammy/Dockerfile
+++ b/jammy/Dockerfile
@@ -87,6 +87,7 @@ RUN \
         util-linux \
         valgrind \
         wget \
+        libcap-dev \
     && cd /tmp \
     && if [ -n "${ONLOAD_PACKAGE_URL}" ] ; then \
           curl --insecure -fSL "${ONLOAD_PACKAGE_URL}" -o /tmp/onload-${ONLOAD_VERSION}-package.zip \


### PR DESCRIPTION
Minor changes to support Ubuntu Builds 18, 20 and 22.